### PR TITLE
Faster whitespace detection

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -46,7 +46,7 @@ func countWhitespace(br *byteReader) int {
 	w := br.window()
 	for {
 		for _, c := range w {
-			if whitespace[c] {
+			if isWhitespace(c) {
 				n++
 			}
 		}

--- a/scanner.go
+++ b/scanner.go
@@ -17,13 +17,6 @@ const (
 	Null        = 'n' // n
 )
 
-var whitespace = [256]bool{
-	' ':  true,
-	'\r': true,
-	'\n': true,
-	'\t': true,
-}
-
 // NewScanner returns a new Scanner for the io.Reader r.
 // A Scanner reads from the supplied io.Reader and produces via Next a stream
 // of tokens, expressed as []byte slices.
@@ -65,8 +58,7 @@ func (s *Scanner) Next() []byte {
 	pos := 0
 	for {
 		for _, c := range w {
-			// strip any leading whitespace.
-			if whitespace[c] {
+			if isWhitespace(c) {
 				pos++
 				continue
 			}
@@ -108,6 +100,10 @@ func (s *Scanner) Next() []byte {
 		}
 		w = s.br.window()[pos:]
 	}
+}
+
+func isWhitespace(c byte) bool {
+	return c <= ' ' && (c == ' ' || c == '\n' || c == '\r' || c == '\t')
 }
 
 func validateToken(br *byteReader, expected string) int {


### PR DESCRIPTION
Lookup via a [256]bool table is cache inefficient and for most inputs
which have at least one whitespace character not as fast as a brute
force comparision.

The degredation in the canada example is measurable, but this is because
canada.json has little whitespace and is dominated by number parsing. I
have some plans to improve the performance of parseNumber so perhaps
this change is worthwhile.
```
name                             old time/op    new time/op    delta
Scanner/canada.json.gz-16          3.56ms ± 1%    3.68ms ± 0%   +3.20%  (p=0.008 n=5+5)
Scanner/citm_catalog.json.gz-16    1.57ms ± 1%    1.48ms ± 1%   -5.70%  (p=0.008 n=5+5)
Scanner/twitter.json.gz-16          849µs ± 1%     823µs ± 0%   -3.00%  (p=0.008 n=5+5)
Scanner/code.json.gz-16            3.69ms ± 1%    3.76ms ± 1%   +1.70%  (p=0.008 n=5+5)
Scanner/example.json.gz-16         16.8µs ± 1%    16.3µs ± 0%   -3.11%  (p=0.008 n=5+5)
Scanner/sample.json.gz-16           476µs ± 0%     418µs ± 1%  -12.32%  (p=0.008 n=5+5)

name                             old speed      new speed      delta
Scanner/canada.json.gz-16         632MB/s ± 1%   612MB/s ± 0%   -3.10%  (p=0.008 n=5+5)
Scanner/citm_catalog.json.gz-16  1.10GB/s ± 1%  1.16GB/s ± 1%   +6.05%  (p=0.008 n=5+5)
Scanner/twitter.json.gz-16        744MB/s ± 1%   767MB/s ± 0%   +3.10%  (p=0.008 n=5+5)
Scanner/code.json.gz-16           525MB/s ± 1%   517MB/s ± 1%   -1.67%  (p=0.008 n=5+5)
Scanner/example.json.gz-16        775MB/s ± 1%   799MB/s ± 0%   +3.21%  (p=0.008 n=5+5)
Scanner/sample.json.gz-16        1.44GB/s ± 0%  1.65GB/s ± 1%  +14.06%  (p=0.008 n=5+5)

name                             old alloc/op   new alloc/op   delta
Scanner/canada.json.gz-16           0.00B          0.00B          ~     (all equal)
Scanner/citm_catalog.json.gz-16     0.00B          0.00B          ~     (all equal)
Scanner/twitter.json.gz-16          0.00B          0.00B          ~     (all equal)
Scanner/code.json.gz-16             0.00B          0.00B          ~     (all equal)
Scanner/example.json.gz-16          0.00B          0.00B          ~     (all equal)
Scanner/sample.json.gz-16           0.00B          0.00B          ~     (all equal)

name                             old allocs/op  new allocs/op  delta
Scanner/canada.json.gz-16            0.00           0.00          ~     (all equal)
Scanner/citm_catalog.json.gz-16      0.00           0.00          ~     (all equal)
Scanner/twitter.json.gz-16           0.00           0.00          ~     (all equal)
Scanner/code.json.gz-16              0.00           0.00          ~     (all equal)
Scanner/example.json.gz-16           0.00           0.00          ~     (all equal)
Scanner/sample.json.gz-16            0.00           0.00          ~     (all equal)
```