### PR TITLE
Make validateToken a function

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -77,11 +77,14 @@ func (s *Scanner) Next() []byte {
 				length = 1
 				s.pos = 1
 			case True:
-				length = s.validateToken("true")
+				length = validateToken(&s.br, "true")
+				s.pos = length
 			case False:
-				length = s.validateToken("false")
+				length = validateToken(&s.br, "false")
+				s.pos = length
 			case Null:
-				length = s.validateToken("null")
+				length = validateToken(&s.br, "null")
+				s.pos = length
 			case String:
 				// string
 				length = s.parseString()
@@ -106,24 +109,23 @@ func (s *Scanner) Next() []byte {
 	}
 }
 
-func (s *Scanner) validateToken(expected string) int {
+func validateToken(br *byteReader, expected string) int {
 	n := len(expected)
-	w := s.br.window()
+	w := br.window()
 	for {
 		if n <= len(w) {
 			if string(w[:n]) != expected {
 				// doesn't match
 				return 0
 			}
-			s.pos = n
 			return n
 		}
 		// If no data is left, we need to extend
-		if s.br.extend() == 0 {
+		if br.extend() == 0 {
 			// eof
 			return 0
 		}
-		w = s.br.window()
+		w = br.window()
 	}
 }
 


### PR DESCRIPTION
Now the byteReader change is landed, validateToken doesn't need access
to the scanner any more. Rewrite it to take a *byteReader as a faux
receiver. It turns out this is ~1% faster overall, and I prefer the
purity of moving this from a function to a method. If the trend holds
true for parseString and parseNumber, this will make it easier to
refactor the latter.
```
name                             old time/op    new time/op    delta
Scanner/canada.json.gz-16          3.56ms ± 1%    3.50ms ± 0%  -1.65%  (p=0.008 n=5+5)
Scanner/citm_catalog.json.gz-16    1.57ms ± 1%    1.56ms ± 1%  -1.02%  (p=0.008 n=5+5)
Scanner/twitter.json.gz-16          849µs ± 1%     833µs ± 1%  -1.85%  (p=0.008 n=5+5)
Scanner/code.json.gz-16            3.69ms ± 1%    3.62ms ± 1%  -1.96%  (p=0.008 n=5+5)
Scanner/example.json.gz-16         16.8µs ± 1%    16.6µs ± 1%  -1.25%  (p=0.016 n=5+5)
Scanner/sample.json.gz-16           476µs ± 0%     468µs ± 0%  -1.69%  (p=0.008 n=5+5)

name                             old speed      new speed      delta
Scanner/canada.json.gz-16         632MB/s ± 1%   642MB/s ± 0%  +1.68%  (p=0.008 n=5+5)
Scanner/citm_catalog.json.gz-16  1.10GB/s ± 1%  1.11GB/s ± 1%  +1.02%  (p=0.008 n=5+5)
Scanner/twitter.json.gz-16        744MB/s ± 1%   758MB/s ± 1%  +1.89%  (p=0.008 n=5+5)
Scanner/code.json.gz-16           525MB/s ± 1%   536MB/s ± 1%  +2.00%  (p=0.008 n=5+5)
Scanner/example.json.gz-16        775MB/s ± 1%   784MB/s ± 1%  +1.26%  (p=0.016 n=5+5)
Scanner/sample.json.gz-16        1.44GB/s ± 0%  1.47GB/s ± 0%  +1.72%  (p=0.008 n=5+5)

name                             old alloc/op   new alloc/op   delta
Scanner/canada.json.gz-16           0.00B          0.00B         ~     (all equal)
Scanner/citm_catalog.json.gz-16     0.00B          0.00B         ~     (all equal)
Scanner/twitter.json.gz-16          0.00B          0.00B         ~     (all equal)
Scanner/code.json.gz-16             0.00B          0.00B         ~     (all equal)
Scanner/example.json.gz-16          0.00B          0.00B         ~     (all equal)
Scanner/sample.json.gz-16           0.00B          0.00B         ~     (all equal)

name                             old allocs/op  new allocs/op  delta
Scanner/canada.json.gz-16            0.00           0.00         ~     (all equal)
Scanner/citm_catalog.json.gz-16      0.00           0.00         ~     (all equal)
Scanner/twitter.json.gz-16           0.00           0.00         ~     (all equal)
Scanner/code.json.gz-16              0.00           0.00         ~     (all equal)
Scanner/example.json.gz-16           0.00           0.00         ~     (all equal)
Scanner/sample.json.gz-16            0.00           0.00         ~     (all equal)
```