### PR TITLE
Demote parseString to a function

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -87,10 +87,11 @@ func (s *Scanner) Next() []byte {
 				s.pos = length
 			case String:
 				// string
-				length = s.parseString()
+				length = parseString(&s.br)
 				if length < 2 {
 					return nil
 				}
+				s.pos = length
 			default:
 				// ensure the number is correct.
 				length = s.parseNumber()
@@ -129,10 +130,13 @@ func validateToken(br *byteReader, expected string) int {
 	}
 }
 
-func (s *Scanner) parseString() int {
+// parseString returns the length of the string token
+// located at the start of the window or 0 if there is no closing
+// " before the end of the byteReader.
+func parseString(br *byteReader) int {
 	pos := 1
 	escaped := false
-	w := s.br.window()[pos:]
+	w := br.window()[pos:]
 	for {
 		for _, c := range w {
 			pos++
@@ -145,17 +149,16 @@ func (s *Scanner) parseString() int {
 				}
 				if c == '"' {
 					// finished
-					s.pos = pos
 					return pos
 				}
 			}
 		}
 		// need more data from the pipe
-		if s.br.extend() == 0 {
+		if br.extend() == 0 {
 			// EOF.
 			return -1
 		}
-		w = s.br.window()[pos:]
+		w = br.window()[pos:]
 	}
 }
 


### PR DESCRIPTION
After the byteReader change landed the only piece of state parseString
needed from Scanner was pos, which can always be inferred from the
return value, length.

```
name                             old time/op    new time/op    delta
Scanner/canada.json.gz-16          3.48ms ± 1%    3.48ms ± 0%    ~     (p=1.000 n=5+5)
Scanner/citm_catalog.json.gz-16    1.56ms ± 1%    1.54ms ± 1%    ~     (p=0.095 n=5+5)
Scanner/twitter.json.gz-16          831µs ± 1%     822µs ± 1%  -1.14%  (p=0.008 n=5+5)
Scanner/code.json.gz-16            3.64ms ± 0%    3.60ms ± 1%  -1.13%  (p=0.032 n=5+5)
Scanner/example.json.gz-16         16.5µs ± 1%    16.4µs ± 1%    ~     (p=1.000 n=5+5)
Scanner/sample.json.gz-16           469µs ± 1%     467µs ± 3%    ~     (p=0.151 n=5+5)

name                             old speed      new speed      delta
Scanner/canada.json.gz-16         648MB/s ± 1%   646MB/s ± 0%    ~     (p=1.000 n=5+5)
Scanner/citm_catalog.json.gz-16  1.11GB/s ± 1%  1.12GB/s ± 1%    ~     (p=0.095 n=5+5)
Scanner/twitter.json.gz-16        760MB/s ± 1%   769MB/s ± 1%  +1.15%  (p=0.008 n=5+5)
Scanner/code.json.gz-16           533MB/s ± 0%   540MB/s ± 1%  +1.15%  (p=0.032 n=5+5)
Scanner/example.json.gz-16        790MB/s ± 1%   792MB/s ± 1%    ~     (p=1.000 n=5+5)
Scanner/sample.json.gz-16        1.47GB/s ± 1%  1.47GB/s ± 2%    ~     (p=0.151 n=5+5)

name                             old alloc/op   new alloc/op   delta
Scanner/canada.json.gz-16           0.00B          0.00B         ~     (all equal)
Scanner/citm_catalog.json.gz-16     0.00B          0.00B         ~     (all equal)
Scanner/twitter.json.gz-16          0.00B          0.00B         ~     (all equal)
Scanner/code.json.gz-16             0.00B          0.00B         ~     (all equal)
Scanner/example.json.gz-16          0.00B          0.00B         ~     (all equal)
Scanner/sample.json.gz-16           0.00B          0.00B         ~     (all equal)

name                             old allocs/op  new allocs/op  delta
Scanner/canada.json.gz-16            0.00           0.00         ~     (all equal)
Scanner/citm_catalog.json.gz-16      0.00           0.00         ~     (all equal)
Scanner/twitter.json.gz-16           0.00           0.00         ~     (all equal)
Scanner/code.json.gz-16              0.00           0.00         ~     (all equal)
Scanner/example.json.gz-16           0.00           0.00         ~     (all equal)
Scanner/sample.json.gz-16            0.00           0.00         ~     (all equal)
```