### PR TITLE
Speed up scanning by 7-10%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BENCH_OPTS := \
 	-test.run=xxx \
-	-test.bench="DecoderNextToken/pkg" \
+	-test.bench="Scanner" \
 	-test.count=5
 
 benchstat: old.txt new.txt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BENCH_OPTS := \
 	-test.run=xxx \
-	-test.bench="(DecoderNextToken)" \
+	-test.bench="DecoderNextToken/pkg" \
 	-test.count=5
 
 benchstat: old.txt new.txt

--- a/reader.go
+++ b/reader.go
@@ -17,8 +17,8 @@ func (b *byteReader) release(n int) {
 
 // window returns the current window.
 // The window is invalidated by calls to release or extend.
-func (b *byteReader) window() []byte {
-	return b.data[b.offset:]
+func (b *byteReader) window(offset int) []byte {
+	return b.data[b.offset+offset:]
 }
 
 // tuning constants for byteReader.extend.

--- a/reader_test.go
+++ b/reader_test.go
@@ -29,7 +29,7 @@ func BenchmarkCountWhitespace(b *testing.B) {
 
 func countWhitespace(br *byteReader) int {
 	n := 0
-	w := br.window()
+	w := br.window(0)
 	for {
 		for _, c := range w {
 			if whitespace[c] {
@@ -40,6 +40,6 @@ func countWhitespace(br *byteReader) int {
 		if br.extend() == 0 {
 			return n
 		}
-		w = br.window()
+		w = br.window(0)
 	}
 }

--- a/scanner.go
+++ b/scanner.go
@@ -138,18 +138,15 @@ func (s *Scanner) parseString() int {
 	for {
 		for _, c := range w {
 			pos++
-			switch escaped {
-			case true:
+			switch {
+			case escaped:
 				escaped = false
-			case false:
-				if c == '\\' {
-					escaped = true
-				}
-				if c == '"' {
-					// finished
-					s.pos = pos + 1
-					return s.pos
-				}
+			case c == '"':
+				// finished
+				s.pos = pos + 1
+				return s.pos
+			case c == '\\':
+				escaped = true
 			}
 		}
 		// need more data from the pipe

--- a/scanner.go
+++ b/scanner.go
@@ -112,22 +112,21 @@ func (s *Scanner) Next() []byte {
 
 func validateToken(br *byteReader, expected string) int {
 	n := len(expected)
+loop:
 	w := br.window()
-	for {
-		if n <= len(w) {
-			if string(w[:n]) != expected {
-				// doesn't match
-				return 0
-			}
-			return n
-		}
-		// If no data is left, we need to extend
+	if n > len(w) {
+		// not enough data is left, we need to extend
 		if br.extend() == 0 {
 			// eof
 			return 0
 		}
-		w = br.window()
+		goto loop
 	}
+	if string(w[:n]) != expected {
+		// doesn't match
+		return 0
+	}
+	return n
 }
 
 // parseString returns the length of the string token


### PR DESCRIPTION
Small improvements to overall scanning performance
```
name                                 old time/op    new time/op    delta
Scanner/canada-4                       6.16ms ± 0%    5.51ms ± 0%  -10.64%  (p=0.008 n=5+5)
Scanner/citm_catalog-4                 2.48ms ± 1%    2.30ms ± 1%   -7.29%  (p=0.008 n=5+5)
Scanner/twitter-4                      1.25ms ± 1%    1.15ms ± 1%   -7.83%  (p=0.008 n=5+5)
Scanner/code-4                         5.57ms ± 1%    5.19ms ± 1%   -6.75%  (p=0.008 n=5+5)
Scanner/example-4                      25.0µs ± 1%    22.8µs ± 0%   -9.08%  (p=0.008 n=5+5)
Scanner/sample-4                        693µs ± 1%     619µs ± 2%  -10.62%  (p=0.008 n=5+5)
DecoderToken/pkgjson/canada-4          29.4ms ± 0%    29.3ms ± 0%   -0.57%  (p=0.016 n=5+5)
DecoderToken/pkgjson/citm_catalog-4    7.37ms ± 4%    7.16ms ± 2%     ~     (p=0.056 n=5+5)
DecoderToken/pkgjson/twitter-4         3.37ms ± 1%    3.30ms ± 1%   -1.99%  (p=0.008 n=5+5)
DecoderToken/pkgjson/code-4            23.2ms ± 2%    22.7ms ± 1%   -2.29%  (p=0.008 n=5+5)
DecoderToken/pkgjson/example-4         73.5µs ± 0%    72.1µs ± 1%   -1.87%  (p=0.008 n=5+5)
DecoderToken/pkgjson/sample-4          1.14ms ± 1%    1.06ms ± 1%   -7.16%  (p=0.008 n=5+5)

name                                 old speed      new speed      delta
Scanner/canada-4                      365MB/s ± 0%   409MB/s ± 0%  +11.91%  (p=0.008 n=5+5)
Scanner/citm_catalog-4                697MB/s ± 1%   752MB/s ± 1%   +7.87%  (p=0.008 n=5+5)
Scanner/twitter-4                     505MB/s ± 1%   548MB/s ± 1%   +8.49%  (p=0.008 n=5+5)
Scanner/code-4                        349MB/s ± 1%   374MB/s ± 1%   +7.23%  (p=0.008 n=5+5)
Scanner/example-4                     520MB/s ± 1%   572MB/s ± 0%   +9.98%  (p=0.008 n=5+5)
Scanner/sample-4                      993MB/s ± 1%  1111MB/s ± 2%  +11.89%  (p=0.008 n=5+5)
DecoderToken/pkgjson/canada-4        76.5MB/s ± 0%  76.9MB/s ± 0%   +0.56%  (p=0.016 n=5+5)
DecoderToken/pkgjson/citm_catalog-4   234MB/s ± 4%   241MB/s ± 2%     ~     (p=0.056 n=5+5)
DecoderToken/pkgjson/twitter-4        188MB/s ± 1%   191MB/s ± 1%   +2.03%  (p=0.008 n=5+5)
DecoderToken/pkgjson/code-4          83.5MB/s ± 2%  85.4MB/s ± 1%   +2.34%  (p=0.008 n=5+5)
DecoderToken/pkgjson/example-4        177MB/s ± 0%   181MB/s ± 1%   +1.91%  (p=0.008 n=5+5)
DecoderToken/pkgjson/sample-4         602MB/s ± 1%   649MB/s ± 1%   +7.71%  (p=0.008 n=5+5)
```