### PR TITLE
Improvements to number parsing

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -110,22 +110,22 @@ loop:
 }
 
 func validateToken(br *byteReader, expected string) int {
-	n := len(expected)
-loop:
-	w := br.window(0)
-	if n > len(w) {
+	for {
+		w := br.window(0)
+		n := len(expected)
+		if len(w) >= n {
+			if string(w[:n]) != expected {
+				// doesn't match
+				return 0
+			}
+			return n
+		}
 		// not enough data is left, we need to extend
 		if br.extend() == 0 {
 			// eof
 			return 0
 		}
-		goto loop
 	}
-	if string(w[:n]) != expected {
-		// doesn't match
-		return 0
-	}
-	return n
 }
 
 // parseString returns the length of the string token

--- a/scanner.go
+++ b/scanner.go
@@ -175,6 +175,7 @@ func (s *Scanner) parseNumber() int {
 	w := s.br.window(0)
 	// int vs uint8 costs 10% on canada.json
 	var state uint8 = begin
+done:
 	for {
 		for _, elem := range w {
 			switch state {
@@ -208,8 +209,7 @@ func (s *Scanner) parseNumber() int {
 				case 'e', 'E':
 					state = exponent
 				default:
-					s.pos = pos
-					return pos // finished
+					break done
 				}
 			case decimal:
 				if elem >= '0' && elem <= '9' {
@@ -245,8 +245,7 @@ func (s *Scanner) parseNumber() int {
 				if elem >= '0' && elem <= '9' {
 					break
 				}
-				s.pos = pos
-				return pos // finished
+				break done
 			}
 			pos++
 		}
@@ -257,8 +256,7 @@ func (s *Scanner) parseNumber() int {
 			// sure we are in a state that allows ending the number.
 			switch state {
 			case leadingzero, anydigit1, anydigit2, anydigit3:
-				s.pos = pos
-				return pos // finished.
+				break done
 			default:
 				// error otherwise, the number isn't complete.
 				return -1
@@ -266,6 +264,8 @@ func (s *Scanner) parseNumber() int {
 		}
 		w = s.br.window(pos)
 	}
+	s.pos = pos
+	return pos // finished.
 }
 
 // Error returns the first error encountered.

--- a/scanner.go
+++ b/scanner.go
@@ -187,12 +187,11 @@ done:
 				}
 				fallthrough
 			case sign:
-				switch elem {
-				case '0':
-					state = leadingzero
-				case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				if elem >= '1' && elem <= '9' {
 					state = anydigit1
-				default:
+				} else if elem == '0' {
+					state = leadingzero
+				} else {
 					// error
 					return -1
 				}
@@ -219,9 +218,10 @@ done:
 					return -1
 				}
 			case anydigit2:
-				switch elem {
-				case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				if elem >= '0' && elem <= '9' {
 					break
+				}
+				switch elem {
 				case 'e', 'E':
 					state = exponent
 				default:
@@ -242,10 +242,9 @@ done:
 					return -1
 				}
 			case anydigit3:
-				if elem >= '0' && elem <= '9' {
-					break
+				if elem < '0' || elem > '9' {
+					break done
 				}
-				break done
 			}
 			pos++
 		}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -164,7 +164,7 @@ func BenchmarkParseNumber(b *testing.B) {
 						r:    r,
 					},
 				}
-				n := scanner.parseNumber()
+				n := scanner.parseNumber(scanner.br.window(0)[0])
 				if n != len(tc) {
 					b.Fatalf("failed")
 				}


### PR DESCRIPTION
```
benchstat {old,new}.txt
name                                     old time/op    new time/op    delta
DecoderNextToken/pkgjson/canada-4          7.25ms ± 0%    7.09ms ± 0%  -2.17%  (p=0.008 n=5+5)
DecoderNextToken/pkgjson/citm_catalog-4    3.11ms ± 1%    3.01ms ± 1%  -3.23%  (p=0.008 n=5+5)
DecoderNextToken/pkgjson/twitter-4         1.48ms ± 1%    1.48ms ± 1%    ~     (p=0.690 n=5+5)
DecoderNextToken/pkgjson/code-4            7.30ms ± 1%    7.26ms ± 1%    ~     (p=0.222 n=5+5)
DecoderNextToken/pkgjson/example-4         30.9µs ± 0%    31.3µs ± 1%  +1.22%  (p=0.008 n=5+5)
DecoderNextToken/pkgjson/sample-4           666µs ± 1%     660µs ± 0%  -0.98%  (p=0.008 n=5+5)

name                                     old speed      new speed      delta
DecoderNextToken/pkgjson/canada-4         311MB/s ± 0%   317MB/s ± 0%  +2.21%  (p=0.008 n=5+5)
DecoderNextToken/pkgjson/citm_catalog-4   556MB/s ± 1%   575MB/s ± 1%  +3.33%  (p=0.008 n=5+5)
DecoderNextToken/pkgjson/twitter-4        428MB/s ± 1%   427MB/s ± 1%    ~     (p=0.643 n=5+5)
DecoderNextToken/pkgjson/code-4           266MB/s ± 1%   267MB/s ± 1%    ~     (p=0.222 n=5+5)
DecoderNextToken/pkgjson/example-4        421MB/s ± 0%   416MB/s ± 1%  -1.20%  (p=0.008 n=5+5)
DecoderNextToken/pkgjson/sample-4        1.03GB/s ± 1%  1.04GB/s ± 0%  +0.99%  (p=0.008 n=5+5)
```