### PR TITLE
Failing test: decoding object key with embeded "

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -201,6 +201,10 @@ func TestDecoderDecode(t *testing.T) {
 		},
 	})
 
+	// Object key with backslashes
+	decode(`{"a\"b":0}`, &any)
+	assert(any, map[string]interface{}{`a"b`: 0.0})
+
 	ms := make(map[string]string)
 	decode(`{"hello": "world"}`, &ms)
 	assert(ms, map[string]string{


### PR DESCRIPTION
This PR contains a failing test for an incorrect decoding of object key containing `"`.

Test case:
```json
{"a\"b":0}
```